### PR TITLE
Protect against case where LBForum user profile not created, and trying to update last activity

### DIFF
--- a/lbforum/models.py
+++ b/lbforum/models.py
@@ -287,7 +287,7 @@ def update_forum_on_topic(sender, instance, created, **kwargs):
 
 def update_user_last_activity(sender, instance, created, **kwargs):
     if instance.user:
-        p = instance.user.lbforum_profile
+        p, created = LBForumUserProfile.objects.get_or_create(user=instance.user)
         p.last_activity = instance.updated_on
         p.save()
 


### PR DESCRIPTION
Disclaimer: I am a noob at contributing to open source stuff.

Found this little bug where I create an empty Django project, syncdb, and add a super user during the process.  Then I add LBForum and do a migrate.

When I logged into the Django admin, it was complaining that a LBForum user profile did not exist for the super user I created during the syncdb.  This little get_or_create fixes that for me.  Perhaps I am installing LBForum incorrectly?
