### PR TITLE
Fix url error: lbforum_user_profile

### DIFF
--- a/lbforum/templates/lbforum/forum.html
+++ b/lbforum/templates/lbforum/forum.html
@@ -32,7 +32,7 @@
       </div>
       <div class="inner">
         {% for o in forum.admins.all %}
-          <a class="item_node" href="{% url 'lbforum_user_profile' o.pk %}">
+          <a class="item_node" href="{% url 'lbforum_profile' o.pk %}">
             <span> {{ o.lbforum_profile }} </span>
           </a>
         {% endfor %}


### PR DESCRIPTION
There's no lbforum_user_profile URL so it will cause the NoReverseMatch error.
This URL should be lbforum_profile.

Error message:

NoReverseMatch at /forum/movie/

Reverse for 'lbforum_user_profile' with arguments '(1L,)' and keyword arguments
'{}' not found. 0 pattern(s) tried: []

Request Method:     GET
Request URL:    https://lpars.cn.ibm.com/forum/movie/
Django Version:     1.10.2
Exception Type:     NoReverseMatch
Exception Value:

Reverse for 'lbforum_user_profile' with arguments '(1L,)' and keyword arguments
'{}' not found. 0 pattern(s) tried: []

Exception Location:
/usr/lib64/python2.7/site-packages/django/urls/resolvers.py in
_reverse_with_prefix, line 392
Python Executable:  /usr/bin/python
Python Version:     2.7.8
Python Path:

['/usr/lib/python2.7/site-packages/django_bower-5.2.0-py2.7.egg',
 '/usr/lib64/python27.zip',
 '/usr/lib64/python2.7',
 '/usr/lib64/python2.7/plat-linux2',
 '/usr/lib64/python2.7/lib-tk',
 '/usr/lib64/python2.7/lib-old',
 '/usr/lib64/python2.7/lib-dynload',
 '/usr/lib64/python2.7/site-packages',
 '/usr/lib64/python2.7/site-packages/gtk-2.0',
 '/usr/lib/python2.7/site-packages',
 '/var/www/html/LPAR-reservation-system']

Signed-off-by: Wang,Sen <wangsen@linux.vnet.ibm.com>